### PR TITLE
tweak: increase size of /boot

### DIFF
--- a/unattended/files/partitioning-recipe-bios.txt
+++ b/unattended/files/partitioning-recipe-bios.txt
@@ -2,7 +2,7 @@ disk_layout ::
         1 1 1 fat32
                 method{ biosgrub }
         .
-        256 100008 256 ext4
+        580 100008 580 ext4
                 $primary{ }
                 method{ format } format{ }
                 use_filesystem{ } filesystem{ ext4 }

--- a/unattended/files/partitioning-recipe-efi.txt
+++ b/unattended/files/partitioning-recipe-efi.txt
@@ -10,7 +10,7 @@ disk_layout ::
                 method{ efi } format{ }
                 mountpoint{ /boot/efi }
 		      .
-        256 100008 256 ext4
+        580 100008 580 ext4
                 $primary{ }
                 method{ format } format{ }
                 use_filesystem{ } filesystem{ ext4 }


### PR DESCRIPTION
Having a /boot of only 256MB turns out to be too parsimonious. A
single kernel update ends up filling up /boot and can even fail as a
result. A /boot of 580MB feels like it should be easier to live with.